### PR TITLE
Bugfix for sort by qty

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,10 +2,9 @@ class ProductsController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    # @products = current_user.products.filtered_products.order(:name).to_a.paginate(page: params[:page], per_page: 10) unless !current_user
-    # binding.pry
-    @products = current_user.products.filtered_products.custom_sort(sort_column, sort_direction, current_user).to_a.paginate(page: params[:page], per_page: 10) unless !current_user
-    # binding.pry
+    @products = current_user.products.filtered_products.
+      custom_sort(sort_column, sort_direction).
+      paginate(page: params[:page], per_page: 10) unless !current_user
   end
 
   def show

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -21,7 +21,7 @@
       <% @products.each do |product| %>
         <tr>
           <td> <%= link_to product.name, product_path(product) %> </td>
-          <td> <%= product.times_bought(current_user) %> </td>
+          <td> <%= product.line_items_sum %> </td>
           <td> <%= number_to_currency(product.highest_price) %> </td>
           <td> <%= number_to_currency(product.lowest_price) %> </td>
           <td> <%= format_date(product.most_recently_purchased(current_user)) %> </td>


### PR DESCRIPTION
The root cause of the sorting issue was the additional `joins(:line_items)` in `sort_by_qty`. It wasn't needed because line items were already being joins because of the relationship that user has to productions *through* line items. Not sure why it was causing the strange behavior we were observing, but I was able to confirm it was the culprit.

Refactors a bit of the surrounding code and also makes an optimization by using line_items_sum in the view instead of making additional queries to calculate the users total.

Let me know if you have any questions or if by chance this doesn't actually solve the problem. :-P